### PR TITLE
Removal of unused variable 'algorithmFinderRoot' to resolve ESLint warning

### DIFF
--- a/src/components/tree.js
+++ b/src/components/tree.js
@@ -66,7 +66,7 @@ class BinaryTree {
 }
 
 const algorithmFinder = new BinaryTree();
-const algorithmFinderRoot = algorithmFinder.createRoot("Is it a Graph?");
+algorithmFinder.createRoot("Is it a Graph?");
 
 algorithmFinder.addNode("Is it a Graph?", "Is it a Tree?", true);
 algorithmFinder.addNode(
@@ -310,6 +310,5 @@ algorithmFinder.addNode(
   false
 );
 
-// algorithmFinder.printTree(algorithmFinderRoot);
 
 export default algorithmFinder;

--- a/src/components/tree.js
+++ b/src/components/tree.js
@@ -310,5 +310,4 @@ algorithmFinder.addNode(
   false
 );
 
-
 export default algorithmFinder;


### PR DESCRIPTION
This PR addresses the issue #4  raised, that highlighted ESLintwarning. 

Key Changes Made:
1. Removed 'algorithmFinderRoot' and instead directly called createRoot method that sets the root inside algorithmFinder.
2. Removed the commented line used for debugging.

Tested the App:
Works fine on local after changes made.